### PR TITLE
Implements /api/weather route and a frontend script for ease of use

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,4 +5,5 @@ export default async (app: Express, database: Db) => {
     (await import("./register.js")).default(app, database);
     (await import("./login.js")).default(app, database);
     (await import("./logout.js")).default(app);
+    (await import("./weather.js")).default(app);
 };

--- a/src/api/weather.ts
+++ b/src/api/weather.ts
@@ -1,0 +1,112 @@
+import { Express, Request, Response } from "express";
+
+if (process.env.OPEN_WEATHER_MAP_API_KEY === undefined) {
+    throw new Error("OPEN_WEATHER_MAP_API_KEY environment variable not defined.");
+}
+const OPEN_WEATHER_MAP_API_KEY = process.env.OPEN_WEATHER_MAP_API_KEY;
+
+interface LocationData {
+    longitude: number;
+    latitude: number;
+    units: "metric" | "imperial" | undefined;
+}
+
+interface WeatherData {
+    name: string;
+    main: {
+        temp: number;
+    };
+    weather: [
+        {
+            main: string;
+            description: string;
+        },
+    ];
+}
+
+interface WeatherResponse {
+    location: string;
+    temp: number;
+    weather: {
+        main: string;
+        description: string;
+    };
+}
+
+function isLocationData(data: unknown): data is LocationData {
+    if (typeof data !== "object" || data === null) {
+        return false;
+    }
+
+    const obj = data as Record<string, unknown>;
+    return (
+        typeof obj.longitude === "number" &&
+        typeof obj.latitude === "number" &&
+        (typeof obj.units === "string" || typeof obj.units === "undefined")
+    );
+}
+
+function isWeatherData(data: unknown): data is WeatherData {
+    if (
+        typeof data === "object" &&
+        data !== null &&
+        "name" in data &&
+        "main" in data &&
+        "weather" in data &&
+        typeof data.name === "string" &&
+        typeof data.main === "object" &&
+        data.main !== null &&
+        "temp" in data.main &&
+        typeof data.main.temp === "number" &&
+        Array.isArray(data.weather)
+    ) {
+        return data.weather.reduce((acc: boolean, value: unknown) => {
+            return (
+                acc &&
+                typeof value === "object" &&
+                value !== null &&
+                "main" in value &&
+                typeof value.main === "string" &&
+                "description" in value &&
+                typeof value.description === "string"
+            );
+        }, true);
+    } else {
+        return false;
+    }
+}
+
+export default (app: Express) => {
+    app.post("/api/weather", async (req: Request, res: Response) => {
+        if (isLocationData(req.body)) {
+            req.body.units ??= "metric";
+            const { longitude, latitude, units } = req.body;
+            const WEATHER_RESPONSE = await fetch(
+                `https://api.openweathermap.org/data/2.5/weather?units=${units}&lat=${latitude.toString()}&lon=${longitude.toString()}&appid=${OPEN_WEATHER_MAP_API_KEY}`,
+            );
+            WEATHER_RESPONSE.json()
+                .then(weatherData => {
+                    if (isWeatherData(weatherData)) {
+                        const response: WeatherResponse = {
+                            location: weatherData.name,
+                            temp: weatherData.main.temp,
+                            weather: {
+                                main: weatherData.weather[0].main,
+                                description: weatherData.weather[0].description,
+                            },
+                        };
+                        res.type("application/json").send(JSON.stringify(response));
+                    } else {
+                        res.status(500).send("Internal server error.");
+                        console.error("Error: Unexpected response from OpenWeatherMap.");
+                    }
+                })
+                .catch(() => {
+                    res.status(500).send("Internal server error.");
+                    console.error("Error: Unexpected response from OpenWeatherMap.");
+                });
+        } else {
+            res.status(400).send("Invalid data.");
+        }
+    });
+};

--- a/src/ts/getWeather.ts
+++ b/src/ts/getWeather.ts
@@ -1,0 +1,51 @@
+interface WeatherResponse {
+    location: string;
+    temp: number;
+    weather: {
+        main: string;
+        description: string;
+    };
+}
+
+function isWeatherResponse(data: unknown): data is WeatherResponse {
+    return typeof data === "object" &&
+        data !== null &&
+        "location" in data &&
+        "temp" in data &&
+        "weather" in data &&
+        typeof data.location === "string" &&
+        typeof data.temp === "number" &&
+        typeof data.weather === "object" &&
+        data.weather !== null &&
+        "main" in data.weather &&
+        "description" in data.weather &&
+        typeof data.weather.main === "string" &&
+        typeof data.weather.description === "string";
+}
+
+function getWeather(): Promise<WeatherResponse> {
+    return new Promise((resolve, reject) => {
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        navigator.geolocation.getCurrentPosition(async position => {
+            const response = await fetch("/api/weather", {
+                headers: {
+                    "Content-type": "application/json",
+                },
+                method: "POST",
+                body: JSON.stringify({
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                }),
+            });
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const json = await response.json();
+            if(isWeatherResponse(json)) {
+                resolve(json);
+            } else {
+                reject(new Error("Invalid response from server when getting weather data."));
+            }
+        });
+    });
+}
+
+export default getWeather;


### PR DESCRIPTION
The API route takes a longitude, latitude, and (optionally) the units to use
The front-end script exports a function that gets the longitude and latitude using the JavaScript Geolocation API and uses the API route to get the weather.