### PR TITLE
Disable an eslint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,7 @@ export default tseslint.config(
             },
         },
         rules: {
-            // Example custom rules
+            "@typescript-eslint/no-misused-promises": "off",
             "@typescript-eslint/no-duplicate-type-constituents": "off",
             "no-unused-vars": "off",
             "@typescript-eslint/no-unused-vars": [

--- a/src/ts/getWeather.ts
+++ b/src/ts/getWeather.ts
@@ -25,7 +25,6 @@ function isWeatherResponse(data: unknown): data is WeatherResponse {
 
 function getWeather(): Promise<WeatherResponse> {
     return new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         navigator.geolocation.getCurrentPosition(async position => {
             const response = await fetch("/api/weather", {
                 headers: {
@@ -37,8 +36,7 @@ function getWeather(): Promise<WeatherResponse> {
                     longitude: position.coords.longitude,
                 }),
             });
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            const json = await response.json();
+            const json = await response.json() as unknown;
             if(isWeatherResponse(json)) {
                 resolve(json);
             } else {


### PR DESCRIPTION
Disables @typescript-eslint/no-misused-promises

One of the things that @typescript-eslint/no-misused-promises disallows is returning promises from functions that should return undefined, which is annoying because that happens when you make a function that returns undefined into an async function. This is perfectly okay and has come up multiple times, so I'm disabling the rule.