### PR TITLE
Refactor to include weatherWidget.ejs as a partial and fix related bugs

### DIFF
--- a/public/js/weatherWidget.js
+++ b/public/js/weatherWidget.js
@@ -1,7 +1,6 @@
 // Make sure getWeather.js is compiled from getWeather.ts and available
-import getWeather from './js/getWeather.js';
+import getWeather from './getWeather.js';
 
-// Simple icon mapping (you can expand this)
 const iconMap = {
   'Clear': 'Sunny.svg',
   'Clouds': 'Cloudy.svg',
@@ -13,6 +12,7 @@ const iconMap = {
 async function updateWeather() {
   try {
     const weather = await getWeather();
+    console.log("1");
     
     // Update the DOM
     document.getElementById('weather-city').textContent = weather.location;
@@ -30,5 +30,7 @@ async function updateWeather() {
   }
 }
 
+updateWeather();
+
 // Initialize when page loads
-document.addEventListener('DOMContentLoaded', updateWeather);
+// document.addEventListener('DOMContentLoaded', updateWeather);

--- a/public/js/weatherWidget.js
+++ b/public/js/weatherWidget.js
@@ -12,7 +12,6 @@ const iconMap = {
 async function updateWeather() {
   try {
     const weather = await getWeather();
-    console.log("1");
     
     // Update the DOM
     document.getElementById('weather-city').textContent = weather.location;

--- a/src/ts/getWeather.ts
+++ b/src/ts/getWeather.ts
@@ -24,8 +24,11 @@ function isWeatherResponse(data: unknown): data is WeatherResponse {
 }
 
 function getWeather(): Promise<WeatherResponse> {
+    console.log("2");
     return new Promise((resolve, reject) => {
+        console.log("3");
         navigator.geolocation.getCurrentPosition(async position => {
+            console.log("4");
             const response = await fetch("/api/weather", {
                 headers: {
                     "Content-type": "application/json",

--- a/src/ts/getWeather.ts
+++ b/src/ts/getWeather.ts
@@ -24,11 +24,8 @@ function isWeatherResponse(data: unknown): data is WeatherResponse {
 }
 
 function getWeather(): Promise<WeatherResponse> {
-    console.log("2");
     return new Promise((resolve, reject) => {
-        console.log("3");
         navigator.geolocation.getCurrentPosition(async position => {
-            console.log("4");
             const response = await fetch("/api/weather", {
                 headers: {
                     "Content-type": "application/json",

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -108,18 +108,7 @@
           to your location, displaying current conditions and offering gentle suggestions—like cozy tasks for rainy days
           or movement goals for sunny afternoons.</p>
         <img href="./images/Feature3.png" alt="Feature"></a>
-        <div class="weather-widget">
-          <div class="weather-widget-child-container">
-            <div class="weather-icon">
-              <img id="weather-icon" src="/weather-icons/Cloudy.svg" alt="Weather Icon">
-            </div>
-            <div class="weather-info">
-              <div id="weather-city">Loading...</div>
-              <div id="weather-temp">--°C</div>
-              <div id="weather-desc"></div>
-            </div>
-          </div>
-        </div>
+        <%- include('partials/weatherWidget') %>
       </div>
     </div>
     <!-- Div Container for the About Us Page-->
@@ -185,11 +174,10 @@
         </div>
       </div>
     </div>
+
     <script src="js/script.js" type="module"></script>
-    <script type="module">
-      import { updateWeather } from './js/weatherWidget.js';
-      // Already initialized via DOMContentLoaded
-    </script>
+    <script src="js/weatherWidget.js" type="module"></script>
+
   </body>
 
   </html>

--- a/views/partials/weatherWidget.ejs
+++ b/views/partials/weatherWidget.ejs
@@ -1,0 +1,12 @@
+<div class="weather-widget">
+    <div class="weather-widget-child-container">
+      <div class="weather-icon">
+        <img id="weather-icon" src="/weather-icons/Cloudy.svg" alt="Weather Icon">
+      </div>
+      <div class="weather-info">
+        <div id="weather-city">Vancouver</div>
+        <div id="weather-temp">22°C</div>
+        <div id="weather-desc"></div>
+      </div>
+    </div>
+</div>


### PR DESCRIPTION
Refactored the weather widget to be included as a partial view since it is likely to be included in multiple files, as well as fix some bugs preventing `getWeather()` from being executed.

Back end for the widget should be good for now, however unclear if front end works; needs followup from @ahjgithub02 and @daryanthedev.

Currently getting rate-limited by Google so hard to test right now, but should be fine. CC @Nerentra to confirm?