### PR TITLE
Implement sophisticated errors

### DIFF
--- a/src/api/account/setUsername.ts
+++ b/src/api/account/setUsername.ts
@@ -2,6 +2,7 @@ import { Express, Request, Response } from "express";
 import { Db, ObjectId } from "mongodb";
 
 import { isUsername, Username } from "../../schema.js";
+import StatusError from "../../utils/statusError.js";
 
 // Data required to set a new username for the user.
 interface SetUsernameData {
@@ -28,14 +29,13 @@ function isSetUsernameData(data: unknown): data is SetUsernameData {
  * @param {Db} database - The MongoDB database instance.
  */
 export default (app: Express, database: Db) => {
-    app.post("/api/account/setUsername", (req: Request, res: Response) => {
+    app.post("/api/account/setUsername", async (req: Request, res: Response) => {
         if (req.session.loggedInUserId === undefined) {
-            res.status(401).send("Please authenticate first.");
-            return;
+            throw new StatusError(401, "Please authenticate first");
         }
         if (isSetUsernameData(req.body)) {
             const { username } = req.body;
-            database
+            await database
                 .collection("users")
                 .updateOne(
                     {
@@ -46,16 +46,10 @@ export default (app: Express, database: Db) => {
                             username,
                         },
                     },
-                )
-                .then(() => {
-                    res.send();
-                })
-                .catch((err: unknown) => {
-                    console.error("Error updating username:", err);
-                    res.status(500).send("Internal server error.");
-                });
+                );
+            res.send();
         } else {
-            res.status(400).send("Invalid data.");
+            throw new StatusError(400, "Invalid data");
         }
     });
 };

--- a/src/api/auth/login.ts
+++ b/src/api/auth/login.ts
@@ -3,6 +3,7 @@ import { Db } from "mongodb";
 
 import * as hash from "../../utils/hash.js";
 import { isUsersSchema, isUsername, isEmail, isPassword, Username, Email, Password } from "../../schema.js";
+import StatusError from "../../utils/statusError.js";
 
 // Data required for login: username/email and password.
 interface LoginData {
@@ -60,11 +61,9 @@ export default (app: Express, database: Db) => {
                     return;
                 }
             }
-            res.status(401).send("Incorrect login data.");
-            return;
+            throw new StatusError(401, "Incorrect login data");
         } else {
-            res.status(400).send("Invalid data.");
-            return;
+            throw new StatusError(400, "Invalid data");
         }
     });
 };

--- a/src/api/enemy/damage.ts
+++ b/src/api/enemy/damage.ts
@@ -1,6 +1,7 @@
 import { Express, Request, Response } from "express";
 import { Db } from "mongodb";
 import { damageEnemy } from "../../utils/enemyUtils.js";
+import StatusError from "../../utils/statusError.js";
 
 // Data passed to the damage api.
 interface DamageData {
@@ -29,22 +30,13 @@ function isDamageData(data: unknown): data is DamageData {
 export default (app: Express, database: Db) => {
     app.post("/api/enemy/damage", async (req: Request, res: Response) => {
         if (req.session.loggedInUserId === undefined) {
-            res.status(401).send("Please authenticate first.");
-            return;
+            throw new StatusError(401, "Please authenticate first");
         }
-
         if (!isDamageData(req.body)) {
-            res.status(400).send("Invalid damage value.");
-            return;
+            throw new StatusError(400, "Invalid damage value");
         }
 
-        try {
-            const newEnemyStatus = await damageEnemy(req, database, req.body.damage);
-            res.json(JSON.stringify(newEnemyStatus));
-        } catch (err) {
-            console.error("Error damaging enemy:", err);
-            res.status(500).send("Internal server error.");
-            return;
-        }
+        const newEnemyStatus = await damageEnemy(req, database, req.body.damage);
+        res.json(JSON.stringify(newEnemyStatus));
     });
 };

--- a/src/api/enemy/info.ts
+++ b/src/api/enemy/info.ts
@@ -1,6 +1,7 @@
 import { Express, Request, Response } from "express";
 import { Db } from "mongodb";
-import { getEnemyInfo, EnemyInfo } from "../../utils/enemyUtils.js";
+import { getEnemyInfo } from "../../utils/enemyUtils.js";
+import StatusError from "../../utils/statusError.js";
 
 /**
  * Registers the /api/enemy/info endpoint to provide the enemy's info.
@@ -10,19 +11,10 @@ import { getEnemyInfo, EnemyInfo } from "../../utils/enemyUtils.js";
 export default (app: Express, database: Db) => {
     app.get("/api/enemy/info", async (req: Request, res: Response) => {
         if (req.session.loggedInUserId === undefined) {
-            res.status(401).send("Please authenticate first.");
-            return;
+            throw new StatusError(401, "Please authenticate first");
         }
 
-        let enemyInfo: EnemyInfo;
-        try {
-            enemyInfo = await getEnemyInfo(req, database);
-        } catch (err) {
-            console.error("Error getting monster health:", err);
-            res.status(500).send("Internal server error.");
-            return;
-        }
-
+        const enemyInfo = await getEnemyInfo(req, database);
         res.type("application/json").send(JSON.stringify(enemyInfo));
     });
 };

--- a/src/api/streak/continue.ts
+++ b/src/api/streak/continue.ts
@@ -1,5 +1,6 @@
 import { Express, Request, Response } from "express";
 import { Db, ObjectId } from "mongodb";
+import StatusError from "../../utils/statusError.js";
 
 /**
  * Registers the /api/streak/continue endpoint to update the user's last streak date to now.
@@ -7,12 +8,11 @@ import { Db, ObjectId } from "mongodb";
  * @param {Db} database - The MongoDB database instance.
  */
 export default (app: Express, database: Db) => {
-    app.post("/api/streak/continue", (req: Request, res: Response) => {
+    app.post("/api/streak/continue", async (req: Request, res: Response) => {
         if (req.session.loggedInUserId === undefined) {
-            res.status(401).send("Please authenticate first.");
-            return;
+            throw new StatusError(401, "Please authenticate first");
         }
-        database
+        await database
             .collection("users")
             .updateOne(
                 {
@@ -23,13 +23,7 @@ export default (app: Express, database: Db) => {
                         lastStreakDate: new Date(),
                     },
                 },
-            )
-            .then(() => {
-                res.send();
-            })
-            .catch((err: unknown) => {
-                console.error("Error inserting user into database:", err);
-                res.status(500).send("Internal server error.");
-            });
+            );
+        res.send();
     });
 };

--- a/src/api/streak/info.ts
+++ b/src/api/streak/info.ts
@@ -1,6 +1,7 @@
 import { Express, Request, Response } from "express";
 import { isUsersSchema } from "../../schema.js";
 import { Db, ObjectId } from "mongodb";
+import StatusError from "../../utils/statusError.js";
 
 /**
  * Registers the /api/streak/info endpoint to provide the user's last streak date.
@@ -8,31 +9,25 @@ import { Db, ObjectId } from "mongodb";
  * @param {Db} database - The MongoDB database instance.
  */
 export default (app: Express, database: Db) => {
-    app.get("/api/streak/info", (req: Request, res: Response) => {
+    app.get("/api/streak/info", async (req: Request, res: Response) => {
         if (req.session.loggedInUserId === undefined) {
-            res.status(401).send("Please authenticate first.");
-            return;
+            throw new StatusError(401, "Please authenticate first");
         }
-        database
+
+        const user = await database
             .collection("users")
             .findOne({
                 _id: new ObjectId(req.session.loggedInUserId),
-            })
-            .then(user => {
-                if (isUsersSchema(user)) {
-                    res.type("application/json").send(
-                        JSON.stringify({
-                            lastStreakDate: user.lastStreakDate,
-                        }),
-                    );
-                } else {
-                    console.error("User from database does not match expected schema");
-                    res.status(500).send("Internal server error.");
-                }
-            })
-            .catch((err: unknown) => {
-                console.error("Error getting user from database:", err);
-                res.status(500).send("Internal server error.");
             });
+
+        if (isUsersSchema(user)) {
+            res.json(
+                JSON.stringify({
+                    lastStreakDate: user.lastStreakDate,
+                }),
+            );
+        } else {
+            throw new Error("User from database does not match expected schema");
+        }
     });
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import "dotenv/config"; // Load .env file
 import sessionMiddleware from "./middleware/session.js";
 import database from "./utils/databaseConnection.js";
 import loadRoutes from "./utils/loadRoutes.js";
+import StatusError from "./utils/statusError.js";
 
 if (process.env.MONGODB_DBNAME === undefined) {
     throw new Error("MONGODB_DBNAME environment variable not defined.");
@@ -47,11 +48,28 @@ await Promise.all([loadRoutes("./src/api", APP, MONGODB_DATABASE), loadRoutes(".
 APP.use(express.static(PUBLIC_ROOT));
 
 // Serve a 404 page for any other routes
-APP.use((_, res: Response) => {
-    res.status(404).render("error", {
-        errorCode: "404",
-        errorName: "Page not found",
-    });
+APP.use(() => {
+    throw new StatusError(404, "Looks like this path leads to a dead end... even the goblins are confused", true);
+});
+
+// Handle errors
+APP.use((err: Error | StatusError, _req: unknown, res: Response, _next: unknown) => {
+    let sErr: StatusError;
+    if(err instanceof StatusError) {
+        sErr = err;
+    } else {
+        sErr = new StatusError(500, "An unexpected error occurred", true);
+        console.error(err);
+    }
+    if(sErr.html) {
+        res.status(sErr.status).render("error", {
+            errorCode: sErr.status,
+            errorName: sErr.name,
+            errorMessage: sErr.message,
+        });
+    } else {
+        res.status(sErr.status).send(sErr.message);
+    }
 });
 
 APP.listen(PORT, () => {

--- a/src/routes/root.ts
+++ b/src/routes/root.ts
@@ -29,12 +29,7 @@ export default (app: Express, database: Db) => {
             // If the user is logged in, get the username from the database
             const user = await database.collection("users").findOne({ _id: new ObjectId(req.session.loggedInUserId) });
             if (!isUsersSchema(user)) {
-                res.status(500).render("error", {
-                    errorCode: "500",
-                    errorName: "Internal server error",
-                });
-                console.error(`Error: Couldn't find user with id "${req.session.loggedInUserId}".`);
-                return;
+                throw new Error("Couldn't find user in database with the ID: " + req.session.loggedInUserId);
             }
             username = user.username;
         } else {

--- a/src/utils/statusError.ts
+++ b/src/utils/statusError.ts
@@ -1,0 +1,34 @@
+const errorNames = {
+    400: "Bad Request",
+    401: "Unauthorized",
+    403: "Forbidden",
+    404: "Page Not Found",
+    500: "Internal Server Error",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    504: "Gateway Timeout",
+};
+
+class StatusError extends Error {
+    status: number;
+    html: boolean;
+
+    constructor(status?: number, message?: string, html?: boolean) {
+        message ??= "An unknown error occurred.";
+        status ??= 500;
+
+        super(message);
+
+        this.message = message;
+        this.status = status;
+        this.html = html ?? false;
+
+        if(Object.keys(errorNames).includes(status.toString())) {
+            this.name = errorNames[status as keyof typeof errorNames];
+        } else {
+            this.name = "Unknown Error";
+        };
+    }
+}
+
+export default StatusError;


### PR DESCRIPTION
I made a custom `StatusError` class that can hold a message, statusCode, and whether to render html or just send the message.
`StatusError`s should be used for an error that should be displayed to the client. They should be set to render html when it is a response the user will see in their browser, and should not render html when it is an API response.
When normal `Error`s are thrown, they are logged to the console and the user is sent the `500 - Internal server error` page. This means normal `Error`s work best for unsolvable server-side errors, such as the database responding incorrectly.